### PR TITLE
add GET /ingredients endpoint with search & pagination

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,32 +1,34 @@
-import express from "express";
-import morgan from "morgan";
-import cors from "cors";
-import path from "path";
-import "dotenv/config";
-import "./db/sequelize.js";
+import express from 'express';
+import morgan from 'morgan';
+import cors from 'cors';
+import path from 'path';
+import 'dotenv/config';
+import './db/sequelize.js';
 
-import healsRouter from "./routes/healthRouter.js";
-import usersRouter from "./routes/usersRouter.js";
+import healsRouter from './routes/healthRouter.js';
+import categoriesRouter from './routes/categoriesRouter.js';
+import ingredientsRouter from './routes/ingredientsRouter.js';
 
 const { APP_PORT = 3000 } = process.env;
 
 const app = express();
 
-app.use(morgan("tiny"));
+app.use(morgan('tiny'));
 app.use(cors());
 app.use(express.json());
 
-app.use(express.static(path.resolve("public")));
+app.use(express.static(path.resolve('public')));
 
-app.use("/api", healsRouter);
-app.use("/api/users", usersRouter);
+app.use('/api', healsRouter);
+app.use('/api/categories', categoriesRouter);
+app.use('/api/ingredients', ingredientsRouter);
 
 app.use((_, res) => {
-  res.status(404).json({ message: "Route not found" });
+  res.status(404).json({ message: 'Route not found' });
 });
 
 app.use((err, req, res, next) => {
-  const { status = 500, message = "Server error" } = err;
+  const { status = 500, message = 'Server error' } = err;
   res.status(status).json({ message });
 });
 

--- a/controllers/ingredientsControllers.js
+++ b/controllers/ingredientsControllers.js
@@ -1,0 +1,35 @@
+import { listIngredients } from '../services/ingredientsServices.js';
+
+export const getIngredients = async (req, res, next) => {
+  try {
+    const {
+      search = '',
+      limit: limitRaw = '10',
+      page: pageRaw = '1',
+    } = req.query;
+
+    let limit = parseInt(limitRaw, 10);
+    if (Number.isNaN(limit) || limit < 1) limit = 10;
+    if (limit > 50) limit = 50;
+
+    let page = parseInt(pageRaw, 10);
+    if (Number.isNaN(page) || page < 1) page = 1;
+
+    const offset = (page - 1) * limit;
+
+    const { rows, count } = await listIngredients({ search, limit, offset });
+
+    res.json({
+      status: 200,
+      message: 'Ingredients retrieved successfully',
+      data: {
+        items: rows,
+        total: count,
+        page,
+        limit,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/db/Ingredient.js
+++ b/db/Ingredient.js
@@ -1,8 +1,9 @@
-import { DataTypes } from 'sequelize';
+import { DataTypes, Model } from 'sequelize';
 import { sequelize } from './sequelize.js';
 
-export const Ingredient = sequelize.define(
-  'Ingredient',
+export class Ingredient extends Model {}
+
+Ingredient.init(
   {
     id: {
       type: DataTypes.UUID,

--- a/db/Ingredient.js
+++ b/db/Ingredient.js
@@ -1,0 +1,31 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from './sequelize.js';
+
+export const Ingredient = sequelize.define(
+  'Ingredient',
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    desc: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    img: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'Ingredient',
+    tableName: 'ingredients',
+    timestamps: false,
+  }
+);

--- a/db/Ingredient.js
+++ b/db/Ingredient.js
@@ -1,9 +1,8 @@
-import { DataTypes, Model } from 'sequelize';
+import { DataTypes } from 'sequelize';
 import { sequelize } from './sequelize.js';
 
-export class Ingredient extends Model {}
-
-Ingredient.init(
+export const Ingredient = sequelize.define(
+  'Ingredient',
   {
     id: {
       type: DataTypes.UUID,

--- a/routes/ingredientsRouter.js
+++ b/routes/ingredientsRouter.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getIngredients } from '../controllers/ingredientsControllers.js';
+
+const router = express.Router();
+
+router.get('/', getIngredients);
+
+export default router;

--- a/services/ingredientsServices.js
+++ b/services/ingredientsServices.js
@@ -1,0 +1,14 @@
+import { Op } from 'sequelize';
+import { Ingredient } from '../db/Ingredient.js';
+
+export const listIngredients = async ({ search, limit = 10, offset = 0 }) => {
+  const where = search ? { name: { [Op.iLike]: `${search}%` } } : {};
+
+  return Ingredient.findAndCountAll({
+    attributes: ['id', 'name', 'desc', 'img'],
+    where,
+    order: [['name', 'ASC']],
+    limit,
+    offset,
+  });
+};


### PR DESCRIPTION
What was done:
Added the Ingredient model, service, controller, and router.
Implemented GET /ingredients endpoint.
Enabled search by first letters (case-insensitive, using iLike).
Implemented pagination with limit and page parameters.
Returning { items, total, page, limit } to make frontend integration easier.

Why this approach:
Ingredients list is large, so we’re limiting responses to improve performance and UX.
Search is case-insensitive to make it more user-friendly.
Added a hard cap of 50 results per request for safety, default is 10.

Frontend plan:
This endpoint will power a dropdown (select) on the frontend.
When a user starts typing the first letters of an ingredient, they will see up to 10 suggestions.
Pagination support allows loading more results if needed.
